### PR TITLE
Enhance error handling

### DIFF
--- a/dopy/manager.py
+++ b/dopy/manager.py
@@ -226,8 +226,14 @@ class DoManager(object):
         except requests.RequestException as e:  # errors from requests
             raise RuntimeError(e)
 
-        if not resp.ok:
-            raise DoError(json['message'])
+        if resp.status_code != requests.codes.ok:
+            if json:
+                if 'error_message' in json:
+                    raise DoError(json['error_message'])
+                elif 'message' in json:
+                    raise DoError(json['message'])
+            # The JSON reponse is bad, so raise an exception with the HTTP status
+            resp.raise_for_status()
         if json.get('status') != 'OK':
             raise DoError(json['error_message'])
 


### PR DESCRIPTION
Although the DigitalOcean API spec says that the error message will be in
the field 'message', I was getting some in the field 'error_message'.  This
was happening with a HTTP error code of 404 so the current code was not
catching it.

The `raise DoError(json['message')` actually raised an exception, namely
`KeyError: message`.   In the Ansible module, this was giving the very
unhelpful error `{ "failed": true, "msg": "message" }`.

This commit adds some error handling to the error handling.
