### PR TITLE
Api updates

### DIFF
--- a/dopy/manager.py
+++ b/dopy/manager.py
@@ -22,12 +22,13 @@ class DoManager(object):
         json = self.request('/droplets/')
         return json['droplets']
 
-    def new_droplet(self, name, size_id, image_id, region_id, ssh_key_ids=None, private_networking=False):
+    def new_droplet(self, name, size_id, image_id, region_id, ssh_key_ids=None, virtio=False, private_networking=False):
         params = {
                 'name': name,
                 'size_id': size_id,
                 'image_id': image_id,
                 'region_id': region_id,
+                'virtio': virtio,
                 'private_networking': private_networking,
             }
         if ssh_key_ids:


### PR DESCRIPTION
This started as a simple request to add the new private_networking option when creating a droplet. I compared the code to Digital Ocean's API docs and found several copy/paste errors and added a couple missing/new methods. The DO API docs have several obvious errors -- sigh. The new virtio, private_networking, and scrub_data parameters have Boolean values. True or False, I'm passing them through (seems safe to be explicit), but you may prefer to only pass through when True. I'm using your dopy via Ansible, so thanks!
