### PR TITLE
Set scrub_data to True by default.

### DIFF
--- a/dopy/manager.py
+++ b/dopy/manager.py
@@ -111,7 +111,7 @@ class DoManager(object):
         return json
 
     def destroy_droplet(self, id, scrub_data=True):
-        params = {'scrub_data': scrub_data}
+        params = {'scrub_data': '1' if scrub_data else '0'}
         json = self.request('/droplets/%s/destroy/' % id, params)
         json.pop('status', None)
         return json


### PR DESCRIPTION
Considering all the outcry in https://github.com/fog/fog/issues/2525, https://github.com/fog/fog/pull/2526, HackerNews and on Twitter, let's just change this to scrub data by default.

People don't always use the optional arguments, but in this case they should. If they want the speed up from not scrubbing data, they can set it to False (as they have to do in Fog as well now).
