### PR TITLE
Fix v2 new_droplet

### DIFF
--- a/dopy/manager.py
+++ b/dopy/manager.py
@@ -41,7 +41,7 @@ class DoManager(object):
                 'backups_enabled': backups_enabled,
             }
             if ssh_key_ids:
-                params['ssh_keys'] = ssh_key_ids
+                params['ssh_keys[]'] = ssh_key_ids
             if user_data:
                 params['user_data'] = user_data
             json = self.request('/droplets', params=params, method='POST')

--- a/dopy/manager.py
+++ b/dopy/manager.py
@@ -29,7 +29,7 @@ class DoManager(object):
 
     def new_droplet(self, name, size_id, image_id, region_id,
             ssh_key_ids=None, virtio=False, private_networking=False,
-            backups_enabled=False):
+            backups_enabled=False, user_data=None):
         if self.api_version == 2:
             params = {
                 'name': name,
@@ -42,6 +42,8 @@ class DoManager(object):
             }
             if ssh_key_ids:
                 params['ssh_keys'] = ssh_key_ids
+            if user_data:
+                params['user_data'] = user_data
             json = self.request('/droplets', params=params, method='POST')
         else:
             params = {


### PR DESCRIPTION
Fixes two issues with v2's `new_droplet`:

- Adds support for the missing `user_data` attribute (unsupported on v1)

- Fixes `ssh_keys` attribute to POST as an array
  The API returns "You specified invalid ssh key ids for Droplet creation." otherwise.