### PR TITLE
Ipv6 support

### DIFF
--- a/dopy/manager.py
+++ b/dopy/manager.py
@@ -49,7 +49,7 @@ class DoManager(object):
                 'virtio': str(virtio).lower(),
                 'ipv6': str(ipv6).lower(),
                 'private_networking': str(private_networking).lower(),
-                'backups_enabled': str(backups_enabled).lower(),
+                'backups': str(backups_enabled).lower(),
             }
             if ssh_key_ids:
                 # Need to be an array in v2

--- a/dopy/manager.py
+++ b/dopy/manager.py
@@ -37,7 +37,7 @@ class DoManager(object):
         return json['droplets']
 
     def new_droplet(self, name, size_id, image_id, region_id,
-            ssh_key_ids=None, virtio=True, private_networking=False,
+            ssh_key_ids=None, virtio=True, ipv6=False, private_networking=False,
             backups_enabled=False, user_data=None):
 
         if self.api_version == 2:
@@ -47,6 +47,7 @@ class DoManager(object):
                 'image': str(image_id),
                 'region': str(region_id),
                 'virtio': str(virtio).lower(),
+                'ipv6': str(ipv6).lower(),
                 'private_networking': str(private_networking).lower(),
                 'backups_enabled': str(backups_enabled).lower(),
             }


### PR DESCRIPTION
This PR adds the ability to set ipv6 as enable on droplet creation. I've also changed the backup parameter name to the correct one as per the docs.

I've not incremented the version number or anything like that.

It's also mentioned https://github.com/digitalocean/api-v2/issues/22 that virtio is no longer supported as an API configurable option but I have refrained from removing that just yet.