### PR TITLE
Fix handling of 'params' argument by droplet_v2_action and image_v2_action

### DIFF
--- a/dopy/manager.py
+++ b/dopy/manager.py
@@ -371,7 +371,7 @@ class DoManager(object):
 
     def edit_domain_record(self, domain_id, record_id, record_type, data, name=None, priority=None, port=None, weight=None):
         if self.api_version == 2:
-            params['name'] = name # API v.2 allows only record name change
+            params = {'name': name} # API v.2 allows only record name change
             json = self.request('/domains/%s/records/%s' % (domain_id, record_id), params, method='PUT')
             return json['domain_record']
 

--- a/dopy/manager.py
+++ b/dopy/manager.py
@@ -97,10 +97,10 @@ class DoManager(object):
                 json['droplet'][u'ip_address'] = ''
         return json['droplet']
 
-    def droplet_v2_action(self, droplet_id, droplet_type, params={}):
-        params = {
-            'type': droplet_type
-        }
+    def droplet_v2_action(self, droplet_id, droplet_type, params=None):
+        if params is None:
+            params = {}
+        params['type'] = droplet_type
         json = self.request('/droplets/%s/actions' % droplet_id, params=params, method='POST')
         return json
 
@@ -236,10 +236,10 @@ class DoManager(object):
         json = self.request('/images/', params)
         return json['images']
 
-    def image_v2_action(self, image_id, image_type, params={}):
-        params = {
-            'type': image_type
-        }
+    def image_v2_action(self, image_id, image_type, params=None):
+        if params is None:
+            params = {}
+        params['type'] = image_type
         json = self.request('/images/%s/actions' % image_id, params=params, method='POST')
         return json
 


### PR DESCRIPTION
The `droplet_v2_action` and `image_v2_action` methods would always override the value of `params`, even when set by the caller, making methods like `rebuild_droplet` always fail with the v2 API.  I fixed that.

I also fixed a NameError in `edit_domain_record` that I noticed.