### PR TITLE
Replace basestring with str type to support Python3

### DIFF
--- a/dopy/manager.py
+++ b/dopy/manager.py
@@ -80,7 +80,7 @@ class DoManager(object):
             }
             if ssh_key_ids:
                 # Need to be an array in v2
-                if isinstance(ssh_key_ids, basestring):
+                if isinstance(ssh_key_ids, str):
                     ssh_key_ids = [ssh_key_ids]
 
                 if type(ssh_key_ids) == list:


### PR DESCRIPTION
Python3 does not have a "basestring" type (as per:
https://stackoverflow.com/questions/34803467/unexpected-exception-name-basestring-is-not-defined-when-invoking-ansible2)
and the recommended action is to replace it with the "str" type.

This was the only instance of it that I managed to find in the repository.

Issue(s): None