### PR TITLE
Fix hyperlink syntax in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Digital Ocean API Python Wrapper
 ================================
 
-Inspired by [dop](https://github.com/ahmontero/dop).
+Inspired by `dop <https://github.com/ahmontero/dop>`_.
 
 Installation
 ============


### PR DESCRIPTION
This is reStructuredText, not Markdown. :-P