### PR TITLE
v2 API now supports all parameters on domain record update

### DIFF
--- a/dopy/manager.py
+++ b/dopy/manager.py
@@ -413,7 +413,16 @@ class DoManager(object):
 
     def edit_domain_record(self, domain_id, record_id, record_type, data, name=None, priority=None, port=None, weight=None):
         if self.api_version == 2:
-            params = {'name': name} # API v.2 allows only record name change
+
+            params = {
+                'name': name,
+                'data': data,
+                'record_type': record_type,
+                'priority': priority,
+                'port': port,
+                'weight': weight
+            }
+
             json = self.request('/domains/%s/records/%s' % (domain_id, record_id), params, method='PUT')
             return json['domain_record']
 


### PR DESCRIPTION
Tested with the current version of the Digital Ocean API. 

https://developers.digitalocean.com/documentation/v2/#update-a-domain-record