### PR TITLE
python3 compatability fix: basestring usage

### DIFF
--- a/dopy/manager.py
+++ b/dopy/manager.py
@@ -11,6 +11,11 @@ from six import wraps
 
 API_ENDPOINT = 'https://api.digitalocean.com'
 
+try:
+    basestring
+except NameError:
+    basestring = str
+
 class DoError(RuntimeError):
     pass
 


### PR DESCRIPTION
This fixes an issue with the module when using Python 3.x when using `ssh_key_ids`